### PR TITLE
Correct node engine field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The fastest javascript implementation of a double-ended queue. Maintains compatability with deque.",
   "main": "index.js",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=0.10"
   },
   "keywords": [
     "data-structure",


### PR DESCRIPTION
In the `README`, as well as in the Travis configuration, the Node version goes down to `0.10`. I think the `package.json` states the wrong minimum version number.