### PR TITLE
Made TypeScript definitions generic and explicit about undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,24 @@
-declare class Denque {
+declare class Denque<T = any> {
   constructor();
-  constructor(array: any[]);
+  constructor(array: T[]);
 
-  push(item: any): number;
-  unshift(item: any): number;
-  pop(): any;
-  removeBack(): any;
-  shift(): any;
-  peekBack(): any;
-  peekFront(): any;
-  peekAt(index: number): any;
-  get(index: number): any;
-  remove(index: number, count: number): any[];
-  removeOne(index: number): any;
-  splice(index: number, count: number, ...item: any[]): any[];
+  push(item: T): number;
+  unshift(item: T): number;
+  pop(): T | undefined;
+  removeBack(): T | undefined;
+  shift(): T | undefined;
+  peekBack(): T | undefined;
+  peekFront(): T | undefined;
+  peekAt(index: number): T | undefined;
+  get(index: number): T | undefined;
+  remove(index: number, count: number): T[];
+  removeOne(index: number): T | undefined;
+  splice(index: number, count: number, ...item: T[]): T[] | undefined;
   isEmpty(): boolean;
   clear(): void;
 
   toString(): string;
-  toArray(): any[];
+  toArray(): T[];
 
   length: number;
 }


### PR DESCRIPTION
The types weren't reaching their potential given the presence of the `any` type, so I added generics to allow for more context when using a Deque. The generic type is defaulted to `any`, so this change should be entirely backwards compatible. I tried to accurately reflect when a type could be `undefined` as well, but that might be worth a look.

I didn't do anything with the version number or anything like that, so let me know if you'd like me to handle that.