### PR TITLE
Make TypeScript interface generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,24 @@
-declare class Denque {
+declare class Denque<T = any> {
   constructor();
-  constructor(array: any[]);
+  constructor(array: T[]);
 
-  push(item: any): number;
-  unshift(item: any): number;
-  pop(): any;
-  removeBack(): any;
-  shift(): any;
-  peekBack(): any;
-  peekFront(): any;
-  peekAt(index: number): any;
-  get(index: number): any;
-  remove(index: number, count: number): any[];
-  removeOne(index: number): any;
-  splice(index: number, count: number, ...item: any[]): any[];
+  push(item: T): number;
+  unshift(item: T): number;
+  pop(): T;
+  removeBack(): T;
+  shift(): T;
+  peekBack(): T;
+  peekFront(): T;
+  peekAt(index: number): T;
+  get(index: number): T;
+  remove(index: number, count: number): T[];
+  removeOne(index: number): T;
+  splice(index: number, count: number, ...item: T[]): T[];
   isEmpty(): boolean;
   clear(): void;
 
   toString(): string;
-  toArray(): any[];
+  toArray(): T[];
 
   length: number;
 }


### PR DESCRIPTION
This shouldn't even be a breaking change. If the generic parameter is omitted, `any` is used.