### PR TITLE
Minor change to push API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Creates an empty double-ended queue with initial capacity of 4.
 
 ```js
 var denque = new Denque();
-denque.push(1, 2, 3);
+denque.push(1);
+denque.push(2);
+denque.push(3);
 denque.shift(); //1
 denque.pop(); //3
 ```


### PR DESCRIPTION
Push does not appear to accept many arguments, so numbers should be separately added in the example for [`new Denque()`](https://github.com/JHamberg/denque/blob/master/README.md#new-denque---denque). This is a minor issue, but bothersome since it is the first example after quick start. Currently the example leads to this behavior:

```js
var denque = new Denque();
denque.push(1, 2, 3);
denque.shift(); //1
denque.pop(); // undefined as 3 was never added
```

This issue is also reflected on https://www.npmjs.com/.