### PR TITLE
Fix SPDX expression.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "email": "mike.diarmid@gmail.com",
     "url": "http://github.com/Salakar/"
   },
-  "license": "APACHE-2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Salakar/denque/issues"
   },


### PR DESCRIPTION
Hi @Salakar 😊 

According to https://spdx.org/licenses/Apache-2.0.html the license should be `Apache-2.0`, not `APACHE-2.0`. I fixed this, because our internal license check failed due to the complete upper casing.

I hope you like it 😊 